### PR TITLE
Updated for Gnome 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Better OSD (GNOME 40 Extension)
+# Better OSD (GNOME 41 Extension)
 
 A GNOME Shell extension allowing the user to set the position, size, transparency and delay of the OSD popup.
 

--- a/metadata.json
+++ b/metadata.json
@@ -4,6 +4,6 @@
   "description": "Customize your OSD popups. Move, resize, set delay and transparency!",
   "uuid": "better-osd@hllvc",
   "url": "https://github.com/hllvc/better-osd",
-  "shell-version": ["40"],
+  "shell-version": ["40", "41"],
   "version": 2.1
 }


### PR DESCRIPTION
Changed `metadata.json` to include gnome 41. 

Tested it and found no issues. 